### PR TITLE
move form submit button into form, clean up react props, change prop …

### DIFF
--- a/src/Cards/AddCard.js
+++ b/src/Cards/AddCard.js
@@ -53,7 +53,7 @@ function AddCard({card}) {
       }
       await createCard(deckId, newCard, abortController.signal);
       // setCard({});
-      history.push(`/decks`);
+      history.push(`/decks/${deckId}`);
 };
 
 const onChangeFrontHandler = (e) => {
@@ -87,7 +87,7 @@ const onChangeBackHandler = (e) => {
       <h1>{`${deck.name}: Add Card`}</h1>
       <div className="card-info">
       <CardForm 
-          handleSubmit={submitHandler}
+          submitHandler={submitHandler}
           onChangeFrontHandler={onChangeFrontHandler}
           onChangeBackHandler={onChangeBackHandler}
           front={front}

--- a/src/Cards/CardForm.js
+++ b/src/Cards/CardForm.js
@@ -11,7 +11,7 @@ function CardForm({ onChangeBackHandler, onChangeFrontHandler, submitHandler, fr
       
       <form onSubmit={submitHandler}>
         <div className="form-group">
-          <label for="front">Front</label>
+          <label htmlFor="front">Front</label>
           <textarea 
           type="text" 
           className="form-control" 
@@ -21,8 +21,8 @@ function CardForm({ onChangeBackHandler, onChangeFrontHandler, submitHandler, fr
           value={front}
           ></textarea>
         </div>
-        <div class="form-group">
-          <label for="back">Back</label>
+        <div className="form-group">
+          <label htmlFor="back">Back</label>
           <textarea 
           type="text" 
           className="form-control" 
@@ -32,9 +32,9 @@ function CardForm({ onChangeBackHandler, onChangeFrontHandler, submitHandler, fr
           value={back}
           ></textarea>
         </div>
+        <button type="button" className="btn btn-secondary mx-1" onClick={() => history.push(`/decks/${deckId}`)}>Done</button>
+        <button type="submit" className="btn btn-primary" >Save</button>
       </form>
-      <button type="button" className="btn btn-secondary mx-1" onClick={() => history.push(`/decks/${deckId}`)}>Done</button>
-      <button type="submit" className="btn btn-primary">Save</button>
     </div>
   )
 }


### PR DESCRIPTION
…names on cardform to match props on addcard

The biggest thing was that the name of the submitHandler prop given to AddCard did not match the name it expected, handleSubmit. Just needed the two components to use the same prop name.

The other big change is that submit buttons on a form need to be inside the form to just work. There are ways of keeping the button out of the form but you have to add more html properties onto the button to specify which form it belongs to. If you just keep the submit button inside the form you don't need to do that.

The rest of the changes are minor cleanup.